### PR TITLE
Add business flag to accounts

### DIFF
--- a/app/controllers/concerns/accountable_resource.rb
+++ b/app/controllers/concerns/accountable_resource.rb
@@ -80,7 +80,7 @@ module AccountableResource
 
     def account_params
       params.require(:account).permit(
-        :name, :balance, :subtype, :currency, :accountable_type, :return_to,
+        :name, :balance, :subtype, :currency, :accountable_type, :business, :return_to,
         accountable_attributes: self.class.permitted_accountable_attributes
       )
     end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -89,7 +89,8 @@ class PropertiesController < ApplicationController
 
     def property_params
       params.require(:account)
-            .permit(:name, :subtype, :accountable_type, accountable_attributes: [ :id, :year_built, :area_unit, :area_value ])
+            .permit(:name, :subtype, :accountable_type, :business,
+                    accountable_attributes: [ :id, :year_built, :area_unit, :area_value ])
     end
 
     def set_property

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -23,6 +23,8 @@ class Account < ApplicationRecord
   scope :liabilities, -> { where(classification: "liability") }
   scope :alphabetically, -> { order(:name) }
   scope :manual, -> { where(plaid_account_id: nil) }
+  scope :business, -> { where(business: true) }
+  scope :personal, -> { where(business: false) }
 
   has_one_attached :logo
 

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -15,6 +15,8 @@
       <%= form.money_field :balance, label: t(".balance"), required: true, default_currency: Current.family.currency %>
     <% end %>
 
+    <%= form.check_box :business, label: t(".business"), class: "ml-0" %>
+
     <%= yield form %>
   </div>
 

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -17,6 +17,7 @@ en:
       balance: Current balance
       name_label: Account name
       name_placeholder: Example account name
+      business: Business account
     index:
       accounts: Accounts
       manual_accounts:

--- a/db/migrate/20250719233000_add_business_to_accounts.rb
+++ b/db/migrate/20250719233000_add_business_to_accounts.rb
@@ -1,0 +1,6 @@
+class AddBusinessToAccounts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :accounts, :business, :boolean, default: false, null: false
+    add_index :accounts, :business
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_18_120146) do
     t.decimal "cash_balance", precision: 19, scale: 4, default: "0.0"
     t.jsonb "locked_attributes", default: {}
     t.string "status", default: "active"
+    t.boolean "business", default: false, null: false
     t.index ["accountable_id", "accountable_type"], name: "index_accounts_on_accountable_id_and_accountable_type"
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["currency"], name: "index_accounts_on_currency"
@@ -45,6 +46,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_18_120146) do
     t.index ["import_id"], name: "index_accounts_on_import_id"
     t.index ["plaid_account_id"], name: "index_accounts_on_plaid_account_id"
     t.index ["status"], name: "index_accounts_on_status"
+    t.index ["business"], name: "index_accounts_on_business"
   end
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -6,6 +6,7 @@ other_asset:
   accountable_type: OtherAsset
   accountable: one
   status: active
+  business: false
 
 other_liability:
   family: dylan_family
@@ -15,6 +16,7 @@ other_liability:
   accountable_type: OtherLiability
   accountable: one
   status: active
+  business: false
 
 depository:
   family: dylan_family
@@ -24,6 +26,7 @@ depository:
   accountable_type: Depository
   accountable: one
   status: active
+  business: false
 
 connected:
   family: dylan_family
@@ -35,6 +38,7 @@ connected:
   accountable: two
   plaid_account: one
   status: active
+  business: false
 
 credit_card:
   family: dylan_family
@@ -44,6 +48,7 @@ credit_card:
   accountable_type: CreditCard
   accountable: one
   status: active
+  business: false
 
 investment:
   family: dylan_family
@@ -54,6 +59,7 @@ investment:
   accountable_type: Investment
   accountable: one
   status: active
+  business: false
 
 loan:
   family: dylan_family
@@ -63,6 +69,7 @@ loan:
   accountable_type: Loan
   accountable: one
   status: active
+  business: false
 
 property:
   family: dylan_family
@@ -72,6 +79,7 @@ property:
   accountable_type: Property
   accountable: one
   status: active
+  business: false
 
 vehicle:
   family: dylan_family


### PR DESCRIPTION
## Summary
- allow accounts to be marked as business
- scope accounts as business or personal
- enable business attribute in account params and forms
- update properties controller strong params
- add business flag to fixtures

## Testing
- `bundle install`
- `bin/rails test` *(fails: ActiveRecord::DatabaseConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_687c2a2a468c83329bf5bdb3d6d9d033